### PR TITLE
Update default docker image from 3.7 to 3.9

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,6 +4,6 @@
   "main_script": "my_script",
   "database": "my_db",
   "table": "dest_table",
-  "docker_image": "digdag/digdag-python:3.7",
+  "docker_image": "digdag/digdag-python:3.9",
   "digdag_path": "digdag"
 }


### PR DESCRIPTION
digdag-python:3.7 will be deprecated soon. So, change the default version to 3.9